### PR TITLE
Fix missing window check in ExpoNetwork web

### DIFF
--- a/packages/expo-network/src/ExpoNetwork.web.ts
+++ b/packages/expo-network/src/ExpoNetwork.web.ts
@@ -36,15 +36,20 @@ class ExpoNetworkModule extends NativeModule<NetworkEvents> {
     return false;
   }
   startObserving() {
+    if (typeof window === 'undefined') {
+      return;
+    }
     this.eventListener = () => this.updateNetworkState();
     window.addEventListener('online', this.eventListener);
     window.addEventListener('offline', this.eventListener);
   }
   stopObserving() {
-    if (this.eventListener) {
-      window.removeEventListener('online', this.eventListener);
-      window.removeEventListener('offline', this.eventListener);
+    if (typeof window === 'undefined' || !this.eventListener) {
+      return;
     }
+    window.removeEventListener('online', this.eventListener);
+    window.removeEventListener('offline', this.eventListener);
+    this.eventListener = undefined;
   }
 }
 


### PR DESCRIPTION
## Summary
- handle undefined `window` in `startObserving` and `stopObserving` for the web implementation of ExpoNetwork

## Testing
- `npm test` *(fails: expo-module not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b187813a0832eba12aabf2b93e614