### PR TITLE
Fix telemetry test expectation

### DIFF
--- a/packages/create-expo/src/__tests__/telemetry.test.ts
+++ b/packages/create-expo/src/__tests__/telemetry.test.ts
@@ -262,10 +262,12 @@ describe('telemetry', () => {
       const [fetchRequestArgs] = fetchAsMock.mock.calls;
       const [, request] = fetchRequestArgs;
       const { batch }: { batch: any[] } = JSON.parse(String(request.body));
-      batch.every(
-        (message) =>
-          message.anonymousId === existingAnonymousId && message.userId === existingUserId
-      );
+      expect(
+        batch.every(
+          (message) =>
+            message.anonymousId === existingAnonymousId && message.userId === existingUserId
+        )
+      ).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
- update telemetry test to assert that batch messages use existing IDs

## Testing
- `yarn workspace create-expo test`

------
https://chatgpt.com/codex/tasks/task_e_687eddbdb60c832eb873bfe39cab00f2