### PR TITLE
Fix typos in error messages

### DIFF
--- a/packages/expo-background-task/ios/BackgorundTaskExceptions.swift
+++ b/packages/expo-background-task/ios/BackgorundTaskExceptions.swift
@@ -37,7 +37,7 @@ internal final class CouldNotRegisterWorker: Exception {
 
 internal final class ErrorInvokingTaskHandler: Exception {
   override var reason: String {
-    "Expo BackgroundTasks: An error occured when running the task handler"
+    "Expo BackgroundTasks: An error occurred when running the task handler"
   }
 }
 

--- a/packages/expo-camera/ios/Common/CameraExceptions.swift
+++ b/packages/expo-camera/ios/Common/CameraExceptions.swift
@@ -50,7 +50,7 @@ internal final class CameraMetadataDecodingException: Exception {
 
 internal final class CameraInvalidPhotoData: Exception {
   override var reason: String {
-    "An error occured while generating photo data"
+    "An error occurred while generating photo data"
   }
 }
 

--- a/packages/expo-print/android/src/main/java/expo/modules/print/PrintExceptions.kt
+++ b/packages/expo-print/android/src/main/java/expo/modules/print/PrintExceptions.kt
@@ -18,7 +18,7 @@ internal class NullUriException :
   CodedException("Given URI is null")
 
 internal class PdfWriteException(cause: Throwable? = null) :
-  CodedException("An error occured while writing the PDF data", cause)
+  CodedException("An error occurred while writing the PDF data", cause)
 
 internal class FileNotFoundException(cause: Throwable? = null) :
   CodedException("Cannot create or open a file", cause)

--- a/packages/expo-video/ios/Cache/MediaFileHandle.swift
+++ b/packages/expo-video/ios/Cache/MediaFileHandle.swift
@@ -17,7 +17,7 @@ internal class MediaFileHandle {
     do {
       return try FileManager.default.attributesOfItem(atPath: filePath)
     } catch let error as NSError {
-      log.warn("An error occured while reading the file attributes at \(filePath) error: \(error)")
+      log.warn("An error occurred while reading the file attributes at \(filePath) error: \(error)")
     }
     return nil
   }


### PR DESCRIPTION
## Summary
- fix "occured" typo in video cache file handle
- fix "occured" typo in camera exceptions
- fix "occured" typo in background task exceptions
- fix "occured" typo in print exceptions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fd2a97b60832e8080c8d193fd8940