### PR TITLE
Add maybeCompleteAuthSession tests

### DIFF
--- a/packages/expo-web-browser/src/__tests__/ExpoWebBrowser-test.web.ts
+++ b/packages/expo-web-browser/src/__tests__/ExpoWebBrowser-test.web.ts
@@ -1,4 +1,7 @@
-import { normalizeUrl, featureObjectToString } from '../ExpoWebBrowser.web';
+import ExpoWebBrowser, {
+  normalizeUrl,
+  featureObjectToString,
+} from '../ExpoWebBrowser.web';
 
 describe(normalizeUrl, () => {
   it(`normalizes url`, async () => {
@@ -27,5 +30,66 @@ describe('featureObjectToString', () => {
         gotMilk: 'yes',
       })
     ).toBe('foo=bar,enabled=yes,disabled=no,gotMilk=yes');
+  });
+});
+
+describe(ExpoWebBrowser.maybeCompleteAuthSession, () => {
+  const getHandle = () => 'ExpoWebBrowserRedirectHandle';
+  const getRedirectUrlHandle = (hash: string) => `ExpoWebBrowser_RedirectUrl_${hash}`;
+
+  let originalWindow: any;
+  let store: Record<string, string>;
+
+  beforeEach(() => {
+    originalWindow = global.window;
+    store = {};
+    (global as any).window = {
+      ...(originalWindow ?? {}),
+      location: {
+        href: 'https://example.com/auth',
+        origin: 'https://example.com',
+        protocol: 'https:',
+        pathname: '/auth',
+      },
+      localStorage: {
+        getItem: jest.fn((key: string) => store[key] ?? null),
+        setItem: jest.fn((key: string, value: string) => {
+          store[key] = value;
+        }),
+        removeItem: jest.fn((key: string) => {
+          delete store[key];
+        }),
+      },
+    };
+  });
+
+  afterEach(() => {
+    if (originalWindow) {
+      (global as any).window = originalWindow;
+    } else {
+      delete (global as any).window;
+    }
+    store = {};
+    jest.resetAllMocks();
+  });
+
+  it('returns failed result when no session handle exists', () => {
+    expect(ExpoWebBrowser.maybeCompleteAuthSession({})).toEqual({
+      type: 'failed',
+      message: 'No auth session is currently in progress',
+    });
+  });
+
+  it('fails when redirect URL does not match current URL', () => {
+    const handle = 'abc';
+    window.localStorage.setItem(getHandle(), handle);
+    window.localStorage.setItem(getRedirectUrlHandle(handle), 'https://other.com/redirect');
+
+    const currentUrl = normalizeUrl(window.location as any);
+    const result = ExpoWebBrowser.maybeCompleteAuthSession({});
+    expect(result).toEqual({
+      type: 'failed',
+      message: `Current URL "${currentUrl}" and original redirect URL "https://other.com/redirect" do not match.`,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- extend web browser tests with coverage for `maybeCompleteAuthSession`

## Testing
- `yarn workspace expo-web-browser test` *(fails: lockfile would have been modified)*

------
https://chatgpt.com/codex/tasks/task_e_687fd2c4eb30832e86a27e5cb934e82d