### PR TITLE
Fix create-expo directory rename regex

### DIFF
--- a/packages/create-expo/src/__tests__/createFileTransformer.test.ts
+++ b/packages/create-expo/src/__tests__/createFileTransformer.test.ts
@@ -17,13 +17,13 @@ describe(modifyFileDuringPipe, () => {
       }).path
     ).toEqual('_package/.vscode/settings.json');
   });
-  it(`does not rename multiple instances of _vscode`, () => {
+  it(`renames multiple instances of _vscode`, () => {
     expect(
       modifyFileDuringPipe({
         path: '_package/_vscode/foo/_vscode/settings.json',
         type: 'File',
       }).path
-    ).toEqual('_package/.vscode/foo/_vscode/settings.json');
+    ).toEqual('_package/.vscode/foo/.vscode/settings.json');
   });
 });
 

--- a/packages/create-expo/src/createFileTransform.ts
+++ b/packages/create-expo/src/createFileTransform.ts
@@ -40,8 +40,11 @@ export function modifyFileDuringPipe(entry: Pick<ReadEntry, 'path' | 'type'>) {
     // For example, if the file is `_vscode`, we want to rename it to `.vscode`.
 
     // Match one instance of the supported directory name, starting with an underscore, and containing slashes on both sides.
-    const regex = new RegExp(`(^|/|\\\\)_(${SUPPORTED_DIRECTORIES.join('|')})(/|\\\\|$)`);
-    entry.path = entry.path.replace(regex, (match, p1, p2, p3) => `${p1}.${p2}${p3}`);
+  const directoryRegex = new RegExp(
+    `(^|/|\\\\)_(${SUPPORTED_DIRECTORIES.join('|')})(/|\\\\|$)`,
+    'g'
+  );
+  entry.path = entry.path.replace(directoryRegex, (_match, p1, p2, p3) => `${p1}.${p2}${p3}`);
   }
   return entry;
 }


### PR DESCRIPTION
## Summary
- update regex in `create-expo` file transformer to replace all `_vscode`-style directories
- update tests for new behaviour
- rename local variable for clarity

## Testing
- `yarn workspace create-expo test`

------
https://chatgpt.com/codex/tasks/task_e_687b17d50b60832e863a29dda6d15b57